### PR TITLE
Add separate text alignment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Fully customize text appearance:
 - **Title Color** - Custom color for the product title
 - **Price Color** - Custom color for the price display
 - **Button Text** - Customize the call-to-action text
+- **Block Alignment** - Left, center or right alignment of the entire card
+- **Text Alignment** - Align text left, center or right within the card
+- **Background Color** - Custom background color for the ad card
+- **Price Size** - Control the price font size
+- **Price Weight** - Normal or bold weight for the price text
 
 ![Amazon Product Edit Interface](docs/images/screenshot_01.png)
 *Screenshot: Configuring an Amazon product block in the Wagtail admin*

--- a/wagtail_amazon_paapi/blocks.py
+++ b/wagtail_amazon_paapi/blocks.py
@@ -87,6 +87,55 @@ class AmazonProductSnippetBlock(StructBlock):
         help_text='Price text color (e.g., #009900 or darkgreen)',
         max_length=20
     )
+
+    alignment = ChoiceBlock(
+        choices=[
+            ('left', 'Left'),
+            ('center', 'Center'),
+            ('right', 'Right'),
+        ],
+        default='left',
+        required=False,
+        help_text='Alignment of the entire product card'
+    )
+
+    text_alignment = ChoiceBlock(
+        choices=[
+            ('left', 'Left'),
+            ('center', 'Center'),
+            ('right', 'Right'),
+        ],
+        default='left',
+        required=False,
+        help_text='Text alignment within the card'
+    )
+
+    background_color = CharBlock(
+        required=False,
+        help_text='Background color for the block (e.g., #ffffff)',
+        max_length=20
+    )
+
+    price_size = ChoiceBlock(
+        choices=[
+            ('small', 'Small'),
+            ('medium', 'Medium (Default)'),
+            ('large', 'Large'),
+        ],
+        default='medium',
+        required=False,
+        help_text='Price font size'
+    )
+
+    price_weight = ChoiceBlock(
+        choices=[
+            ('normal', 'Normal'),
+            ('bold', 'Bold (Default)'),
+        ],
+        default='bold',
+        required=False,
+        help_text='Price font weight'
+    )
     
     button_text = CharBlock(
         required=False,

--- a/wagtail_amazon_paapi/templates/wagtail_amazon_paapi/blocks/amazon_product_content.html
+++ b/wagtail_amazon_paapi/templates/wagtail_amazon_paapi/blocks/amazon_product_content.html
@@ -1,12 +1,15 @@
 <!-- Apply styles directly to each element -->
-<div class="amazon-product" 
-     style="margin: 1.5rem 0; font-family: {{ font_family }}; 
-            {% if self.max_width %}max-width: {{ self.max_width }}px;{% endif %} 
+<div class="amazon-product"
+     style="margin: 1.5rem 0; font-family: {{ font_family }}; display: flex;
+            justify-content: {% if block_alignment == 'center' %}center{% elif block_alignment == 'right' %}flex-end{% else %}flex-start{% endif %};
             {% if self.max_height %}max-height: {{ self.max_height }}px; overflow: auto;{% endif %}">
 
     {% if style_type == "simple" %}
         <!-- Simple Style: Minimal and clean -->
-        <div class="amazon-product__inner" style="display: flex; flex-direction: column; align-items: center; text-align: center; max-width: 350px; margin: 0 auto;">
+        <div class="amazon-product__inner"
+             style="display: flex; flex-direction: column;
+                    align-items: {% if text_alignment == 'center' %}center{% elif text_alignment == 'right' %}flex-end{% else %}flex-start{% endif %};
+                    text-align: {{ text_alignment }}; max-width: {% if self.max_width %}{{ self.max_width }}px{% else %}350px{% endif %}; background-color: {{ background_color }};">
             {% if product.image_url %}
                 <div class="amazon-product__image" style="margin-bottom: 1rem;">
                     <img src="{{ product.image_url }}" alt="{{ product.product_title }}" style="max-width: 100%; height: auto;">
@@ -17,7 +20,7 @@
                     {{ product.product_title }}
                 </h3>
                 {% if product.price %}
-                    <p class="amazon-product__price" style="font-weight: bold; color: {{ price_color }};">{{ product.price }}</p>
+                    <p class="amazon-product__price" style="font-weight: {{ price_weight }}; color: {{ price_color }}; font-size: {% if self.price_size == 'small' %}0.9rem{% elif self.price_size == 'large' %}1.2rem{% else %}1rem{% endif %};">{{ product.price }}</p>
                 {% endif %}
                 <a href="{{ product.affiliate_url }}" class="amazon-product__button" 
                    style="display: inline-block; background-color: var(--amazon-primary); color: white; text-decoration: none; 
@@ -30,8 +33,10 @@
 
     {% elif style_type == "card" %}
         <!-- Card Style: Box-based design with shadow -->
-        <div class="amazon-product__inner" style="padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); 
-                                                 background-color: white; max-width: 350px; margin: 0 auto; text-align: center;">
+        <div class="amazon-product__inner"
+             style="padding: 1.5rem; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+                    background-color: {% if background_color %}{{ background_color }}{% else %}white{% endif %};
+                    max-width: {% if self.max_width %}{{ self.max_width }}px{% else %}350px{% endif %}; text-align: {{ text_alignment }};">
             {% if product.image_url %}
                 <div class="amazon-product__image" style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid var(--amazon-border);">
                     <img src="{{ product.image_url }}" alt="{{ product.product_title }}" style="max-width: 100%; height: auto;">
@@ -42,7 +47,7 @@
                     {{ product.product_title }}
                 </h3>
                 {% if product.price %}
-                    <p class="amazon-product__price" style="font-weight: bold; color: {{ price_color }};">{{ product.price }}</p>
+                    <p class="amazon-product__price" style="font-weight: {{ price_weight }}; color: {{ price_color }}; font-size: {% if self.price_size == 'small' %}0.9rem{% elif self.price_size == 'large' %}1.2rem{% else %}1rem{% endif %};">{{ product.price }}</p>
                 {% endif %}
                 <a href="{{ product.affiliate_url }}" class="amazon-product__button" 
                    style="display: inline-block; background-color: var(--amazon-primary); color: white; text-decoration: none; 
@@ -55,19 +60,22 @@
 
     {% else %}
         <!-- Horizontal Style: Side-by-side layout -->
-        <div class="amazon-product__inner" style="display: flex; align-items: center; padding: 1rem; 
-                                                 border: 1px solid var(--amazon-border); border-radius: 6px;">
+        <div class="amazon-product__inner"
+             style="display: flex; align-items: center; padding: 1rem;
+                    border: 1px solid var(--amazon-border); border-radius: 6px;
+                    background-color: {{ background_color }};
+                    {% if self.max_width %}max-width: {{ self.max_width }}px;{% endif %}">
             {% if product.image_url %}
                 <div class="amazon-product__image" style="flex: 0 0 40%; padding-right: 1.5rem;">
                     <img src="{{ product.image_url }}" alt="{{ product.product_title }}" style="max-width: 100%; height: auto;">
                 </div>
             {% endif %}
-            <div class="amazon-product__content" style="flex: 1;">
+            <div class="amazon-product__content" style="flex: 1; text-align: {{ text_alignment }};">
                 <h3 class="amazon-product__title" style="margin-top: 0; font-size: {{ title_size_px }}; line-height: 1.4; font-weight: {{ title_weight }}; color: {{ title_color }};">
                     {{ product.product_title }}
                 </h3>
                 {% if product.price %}
-                    <p class="amazon-product__price" style="font-weight: bold; color: {{ price_color }};">{{ product.price }}</p>
+                    <p class="amazon-product__price" style="font-weight: {{ price_weight }}; color: {{ price_color }}; font-size: {% if self.price_size == 'small' %}0.9rem{% elif self.price_size == 'large' %}1.2rem{% else %}1rem{% endif %};">{{ product.price }}</p>
                 {% endif %}
                 <a href="{{ product.affiliate_url }}" class="amazon-product__button" 
                    style="display: inline-block; background-color: var(--amazon-primary); color: white; text-decoration: none; 

--- a/wagtail_amazon_paapi/templates/wagtail_amazon_paapi/blocks/amazon_product_snippet.html
+++ b/wagtail_amazon_paapi/templates/wagtail_amazon_paapi/blocks/amazon_product_snippet.html
@@ -19,7 +19,7 @@
 </style>
 
 <!-- Set typography variables -->
-{% with title_size_map=self.title_size|default:'medium' title_size_px='1.1rem' title_weight=self.title_weight|default:'bold' title_color=self.title_color|default:'var(--amazon-text)' price_color=self.price_color|default:'var(--amazon-text)' button_text=self.button_text|default:'Buy on Amazon' font_family=self.font_family|default:'inherit' %}
+{% with title_size_map=self.title_size|default:'medium' title_size_px='1.1rem' title_weight=self.title_weight|default:'bold' title_color=self.title_color|default:'var(--amazon-text)' price_color=self.price_color|default:'var(--amazon-text)' button_text=self.button_text|default:'Buy on Amazon' font_family=self.font_family|default:'inherit' block_alignment=self.alignment|default:'left' text_alignment=self.text_alignment|default:'left' background_color=self.background_color|default:'transparent' price_weight=self.price_weight|default:'bold' %}
 
 <!-- Adjust font size based on selection -->
 {% if title_size_map == 'small' %}


### PR DESCRIPTION
## Summary
- clarify block alignment help text and add new text alignment field
- use block alignment for card positioning and text alignment for card content
- document new options in README
- keep card width unaffected when setting max width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf5dde7f48327b4ffbf011b3767b8