### PR TITLE
Add fieldsets to Amazon block

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,11 @@ By default, `amazon_update_panel.html` contains a button labeled **"Update From 
 
 ## Customizing the Product Template
 
-How an Amazon product snippet is displayed on your site is controlled by `amazon_product_snippet.html`. You can override this template in your own `templates` directory if you want a different design. 
+How an Amazon product snippet is displayed on your site is controlled by `amazon_product_snippet.html`. You can override this template in your own `templates` directory if you want a different design.
+
+## Block Form Layout
+
+`AmazonProductSnippetBlock` groups its settings into **Layout**, **Typography**, and **Price** sections. The admin form includes the CSS class `amazon-product-block-form` and loads `amazon_product_block.css` for basic styling. Override this file if you need further customization.
 
 ---
 

--- a/wagtail_amazon_paapi/blocks.py
+++ b/wagtail_amazon_paapi/blocks.py
@@ -148,3 +148,36 @@ class AmazonProductSnippetBlock(StructBlock):
         icon = "snippet"
         label = "Amazon Product"
         form_classname = "amazon-product-block-form"
+        fieldsets = (
+            ("Layout", {
+                "fields": (
+                    "display_style",
+                    "max_width",
+                    "max_height",
+                    "block_alignment",
+                    "text_alignment",
+                    "background_color",
+                )
+            }),
+            ("Typography", {
+                "fields": (
+                    "font_family",
+                    "title_size",
+                    "title_weight",
+                    "title_color",
+                )
+            }),
+            ("Price", {
+                "fields": (
+                    "price_size",
+                    "price_weight",
+                    "price_color",
+                    "button_text",
+                )
+            }),
+        )
+
+    class Media:
+        css = {
+            "all": ["wagtail_amazon_paapi/css/amazon_product_block.css"]
+        }

--- a/wagtail_amazon_paapi/static/wagtail_amazon_paapi/css/amazon_product_block.css
+++ b/wagtail_amazon_paapi/static/wagtail_amazon_paapi/css/amazon_product_block.css
@@ -1,0 +1,5 @@
+.amazon-product-block-form .fieldset {
+    margin-top: 1rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid #eee;
+}


### PR DESCRIPTION
## Summary
- organize AmazonProductSnippetBlock fields with `Meta.fieldsets`
- add admin styling via `class Media`
- document new block form layout in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d1a9f9af08327924b527351be15f2