### PR TITLE
Refactor AmazonProductSnippetBlock panels

### DIFF
--- a/wagtail_amazon_paapi/blocks.py
+++ b/wagtail_amazon_paapi/blocks.py
@@ -1,5 +1,6 @@
 from wagtail.blocks import StructBlock, ChoiceBlock, IntegerBlock, CharBlock
 from wagtail.snippets.blocks import SnippetChooserBlock
+from wagtail.admin.panels import FieldPanel, FieldRowPanel, MultiFieldPanel
 
 class AmazonProductSnippetBlock(StructBlock):
     """A block for displaying an Amazon Product Snippet with configurable styling."""
@@ -148,34 +149,46 @@ class AmazonProductSnippetBlock(StructBlock):
         icon = "snippet"
         label = "Amazon Product"
         form_classname = "amazon-product-block-form"
-        fieldsets = (
-            ("Layout", {
-                "fields": (
-                    "display_style",
-                    "max_width",
-                    "max_height",
-                    "block_alignment",
-                    "text_alignment",
-                    "background_color",
-                )
-            }),
-            ("Typography", {
-                "fields": (
-                    "font_family",
-                    "title_size",
-                    "title_weight",
-                    "title_color",
-                )
-            }),
-            ("Price", {
-                "fields": (
-                    "price_size",
-                    "price_weight",
-                    "price_color",
-                    "button_text",
-                )
-            }),
-        )
+        panels = [
+            FieldPanel("product"),
+            MultiFieldPanel(
+                [
+                    FieldPanel("display_style"),
+                    FieldRowPanel([
+                        FieldPanel("max_width"),
+                        FieldPanel("max_height"),
+                    ]),
+                    FieldRowPanel([
+                        FieldPanel("block_alignment"),
+                        FieldPanel("text_alignment"),
+                    ]),
+                    FieldPanel("background_color"),
+                ],
+                heading="Layout",
+            ),
+            MultiFieldPanel(
+                [
+                    FieldPanel("font_family"),
+                    FieldRowPanel([
+                        FieldPanel("title_size"),
+                        FieldPanel("title_weight"),
+                    ]),
+                    FieldPanel("title_color"),
+                ],
+                heading="Typography",
+            ),
+            MultiFieldPanel(
+                [
+                    FieldRowPanel([
+                        FieldPanel("price_size"),
+                        FieldPanel("price_weight"),
+                    ]),
+                    FieldPanel("price_color"),
+                    FieldPanel("button_text"),
+                ],
+                heading="Price",
+            ),
+        ]
 
     class Media:
         css = {

--- a/wagtail_amazon_paapi/static/wagtail_amazon_paapi/css/amazon_product_block.css
+++ b/wagtail_amazon_paapi/static/wagtail_amazon_paapi/css/amazon_product_block.css
@@ -1,3 +1,5 @@
+.amazon-product-block-form .w-panel,
+.amazon-product-block-form .panel,
 .amazon-product-block-form .fieldset {
     margin-top: 1rem;
     padding-top: 0.5rem;


### PR DESCRIPTION
## Summary
- replace `fieldsets` with Wagtail panel definitions
- group Layout, Typography, and Price controls with `MultiFieldPanel` and `FieldRowPanel`
- update admin CSS to style panels

## Testing
- `python -m py_compile wagtail_amazon_paapi/blocks.py`

------
https://chatgpt.com/codex/tasks/task_e_685d2b9d11c48327af99b8c0f92f2eb1