### PR TITLE
Add custom form template for Amazon block

### DIFF
--- a/wagtail_amazon_paapi/blocks.py
+++ b/wagtail_amazon_paapi/blocks.py
@@ -1,6 +1,5 @@
 from wagtail.blocks import StructBlock, ChoiceBlock, IntegerBlock, CharBlock
 from wagtail.snippets.blocks import SnippetChooserBlock
-from wagtail.admin.panels import FieldPanel, FieldRowPanel, MultiFieldPanel
 
 class AmazonProductSnippetBlock(StructBlock):
     """A block for displaying an Amazon Product Snippet with configurable styling."""
@@ -144,51 +143,13 @@ class AmazonProductSnippetBlock(StructBlock):
         default='Buy on Amazon'
     )
 
+    form_template = "wagtail_amazon_paapi/blocks/amazon_product_snippet_form.html"
+
     class Meta:
         template = "wagtail_amazon_paapi/blocks/amazon_product_snippet.html"
         icon = "snippet"
         label = "Amazon Product"
         form_classname = "amazon-product-block-form"
-        panels = [
-            FieldPanel("product"),
-            MultiFieldPanel(
-                [
-                    FieldPanel("display_style"),
-                    FieldRowPanel([
-                        FieldPanel("max_width"),
-                        FieldPanel("max_height"),
-                    ]),
-                    FieldRowPanel([
-                        FieldPanel("block_alignment"),
-                        FieldPanel("text_alignment"),
-                    ]),
-                    FieldPanel("background_color"),
-                ],
-                heading="Layout",
-            ),
-            MultiFieldPanel(
-                [
-                    FieldPanel("font_family"),
-                    FieldRowPanel([
-                        FieldPanel("title_size"),
-                        FieldPanel("title_weight"),
-                    ]),
-                    FieldPanel("title_color"),
-                ],
-                heading="Typography",
-            ),
-            MultiFieldPanel(
-                [
-                    FieldRowPanel([
-                        FieldPanel("price_size"),
-                        FieldPanel("price_weight"),
-                    ]),
-                    FieldPanel("price_color"),
-                    FieldPanel("button_text"),
-                ],
-                heading="Price",
-            ),
-        ]
 
     class Media:
         css = {

--- a/wagtail_amazon_paapi/static/wagtail_amazon_paapi/css/amazon_product_block.css
+++ b/wagtail_amazon_paapi/static/wagtail_amazon_paapi/css/amazon_product_block.css
@@ -1,5 +1,3 @@
-.amazon-product-block-form .w-panel,
-.amazon-product-block-form .panel,
 .amazon-product-block-form .fieldset {
     margin-top: 1rem;
     padding-top: 0.5rem;

--- a/wagtail_amazon_paapi/templates/wagtail_amazon_paapi/blocks/amazon_product_snippet_form.html
+++ b/wagtail_amazon_paapi/templates/wagtail_amazon_paapi/blocks/amazon_product_snippet_form.html
@@ -1,0 +1,26 @@
+{% load wagtailadmin_tags %}
+<div class="{{ classname }}">
+    <fieldset>
+        <legend>Layout</legend>
+        {% include "wagtailadmin/shared/field.html" with field=form.display_style %}
+        {% include "wagtailadmin/shared/field.html" with field=form.max_width %}
+        {% include "wagtailadmin/shared/field.html" with field=form.max_height %}
+        {% include "wagtailadmin/shared/field.html" with field=form.block_alignment %}
+        {% include "wagtailadmin/shared/field.html" with field=form.text_alignment %}
+        {% include "wagtailadmin/shared/field.html" with field=form.background_color %}
+    </fieldset>
+    <fieldset>
+        <legend>Typography</legend>
+        {% include "wagtailadmin/shared/field.html" with field=form.font_family %}
+        {% include "wagtailadmin/shared/field.html" with field=form.title_size %}
+        {% include "wagtailadmin/shared/field.html" with field=form.title_weight %}
+        {% include "wagtailadmin/shared/field.html" with field=form.title_color %}
+    </fieldset>
+    <fieldset>
+        <legend>Price</legend>
+        {% include "wagtailadmin/shared/field.html" with field=form.price_size %}
+        {% include "wagtailadmin/shared/field.html" with field=form.price_weight %}
+        {% include "wagtailadmin/shared/field.html" with field=form.price_color %}
+        {% include "wagtailadmin/shared/field.html" with field=form.button_text %}
+    </fieldset>
+</div>


### PR DESCRIPTION
## Summary
- add custom Wagtail form template for block editing
- group Amazon block fields under Layout, Typography and Price fieldsets
- use the new template from `AmazonProductSnippetBlock`
- remove panel layout and panel-related CSS
- fix `form_template` attribute position so the custom template is applied

## Testing
- `python -m py_compile wagtail_amazon_paapi/blocks.py`


------
https://chatgpt.com/codex/tasks/task_e_685d47004a4c83279269957ce6d118a7