### PR TITLE
Remove default_app_config reference

### DIFF
--- a/wagtail_amazon_paapi/__init__.py
+++ b/wagtail_amazon_paapi/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = "wagtail_amazon_paapi.apps.WagtailAmazonPaapiConfig"
+


### PR DESCRIPTION
## Summary
- delete `default_app_config` from `__init__.py`

## Testing
- `python -m py_compile wagtail_amazon_paapi/apps.py wagtail_amazon_paapi/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_685d74e98c0483278baa28f3f3fe7088